### PR TITLE
Blog app - integration specs for views and fix n+1 problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ To use this project modify database.yml file at the development section to speci
 command to run:
 - bundle install
 - bundle exec rspec
+
+command to run for integration test:
+ - rails test:integration
+
  
 ### Deployment
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,6 @@
 class CommentsController < ApplicationController
   def new
-    @post = Post.includes(:user, :comments).find(params[:post_id])
+    @post = Post.includes(:author, :comments).find(params[:post_id])
     @comment = current_user.comments.build
     @current_user = current_user
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,6 @@
 class CommentsController < ApplicationController
   def new
-    @post = Post.find(params[:post_id])
+    @post = Post.includes(:user, :comments).find(params[:post_id])
     @comment = current_user.comments.build
     @current_user = current_user
   end
@@ -9,7 +9,6 @@ class CommentsController < ApplicationController
     @user = current_user
     @post = Post.find_by(id: params[:comment][:post_id])
     if @post.nil?
-      # Handle the case when the post is not found
       redirect_to posts_url, alert: 'Error adding comment: Post not found.'
       return
     end
@@ -18,7 +17,6 @@ class CommentsController < ApplicationController
     if @comment.save
       redirect_to user_posts_path(user_id: @user), notice: 'Comment added successfully.'
     else
-      # Handle validation errors or other errors
       redirect_to user_posts_path(user_id: @user), alert: 'Error adding comment.'
     end
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,12 +2,12 @@
 class PostsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
-    @posts = Post.all
+    @posts = Post.includes(:user).all
   end
 
   def show
     @user = User.find(params[:user_id])
-    @post = @user.posts.find(params[:id])
+    @post = @user.posts.includes(:user).find(params[:id])
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,12 +2,12 @@
 class PostsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
-    @posts = Post.includes(:user).all
+    @posts = Post.includes(:author).all
   end
 
   def show
     @user = User.find(params[:user_id])
-    @post = @user.posts.includes(:user).find(params[:id])
+    @post = @user.posts.includes(:author).find(params[:id])
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
     @user = User.includes(:posts).find(params[:id])
     @users = User.all
   end
-  
+
   def posts
     @user = User.find(params[:user_id])
     @posts = @user.posts

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,18 +1,15 @@
 # app/controllers/users_controller.rb
 class UsersController < ApplicationController
   def index
-    @users = User.all
-    # Add any additional logic you want for displaying all users
+    @users = User.includes(:posts).all
   end
 
   def show
-    @user = User.find(params[:id])
-    # Add any logic you want to perform for the user profile page
+    @user = User.includes(:posts).find(params[:id])
   end
 
   def posts
     @user = User.find(params[:user_id])
     @posts = @user.posts
-    # Add any logic you want to perform for displaying user posts
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Welcome to Blog App</title>
-</head>
-<body>
-  <h1>Welcome to Blog App</h1>
-</body>
-</html>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -14,7 +14,7 @@
     </div>
     <% @user.posts.reverse_each.each_with_index do |post, index| %>
       <div class="post-comment">
-        <%= link_to user_post_path(@user, post),  class: "bio bordered flex-c" do %>
+        <%= link_to user_post_path(user_id: @user.id, id: post.id), id: "user-post-link-#{@user.id}", class: "bio bordered flex-c" do %>
           <p>post #<%= index + 1 %> </p>post-id:  <%= post.id %>
           <span><%= post.text %></span>
         <% end  %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -8,9 +8,11 @@
     <%= link_to new_post_path(@user), class: "btn absolute my-post" do %><p>Add new post</p><% end %>
   <% @users.each do |user| %>
     <div class="users flex-spaced">
-    <div class="user-photo bordered"></div>
+    <div class="user-photo bordered">
+      <img src="<%= user.photo %>">
+    </div>
     <div class="details bordered flex-spaced">
-        <%= link_to user do %>
+        <%= link_to user, class: "user-link", id: "user-link-#{user.id}" do %>
           <div class="user-name"><%= user.name %></div>
         <% end %>
           <div class="post-nums">Number of posts:<%= user.posts.count %> </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,7 +25,7 @@
         <%= link_to user_post_path(@user, post), id: "user-post-link-#{@user.id}",  class: "bio flex-c" do %>
           <p>post #<%= index + 1 %> </p>  </p>post-id:  <%= post.id %>
           <span><%= post.text %></span>
-          <%= link_to new_comment_path(user_id: @user.id, post_id: post.id), class: "mr-1 absolute bottom-left-cornor mb-1 btn" do %><p>Comment on this post</p><% end %>
+          <%= link_to new_comment_path(user_id: @user.id, post_id: post.id), class: "mr-1 absolute bottom-left-cornor mb-1 btn" do %><p>Comment on this postaa</p><% end %>
         <div class="find-me">find-me</div>
         <% end %>
         <div class="comment-likes flex gap-1">
@@ -40,7 +40,7 @@
     <% end %>
     <div class="flex-centered">
     <div class="flex">
-      <%= link_to user_posts_path(@user), class: "btn see-all-posts", title: "See all posts" do %><p>Comment on this posta</p><% end %>
+      <%= link_to user_posts_path(@user), class: "btn see-all-posts", title: "See all posts" do %><p>Comment on this post</p><% end %>
     </div>
     </div>
     </div> 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,7 +6,9 @@
 <body>
   <div class="user-container ">
     <div class="users flex-spaced">
-      <div class="user-photo bordered">Photo</div>
+      <div class="user-photo bordered">
+        <img src="<%= @user.photo %>">
+      </div>
       <div class="details bordered flex-spaced">
           <div class="user-name"><%= @user.name %></div>
           <div class="post-nums">Number of posts: <%= @user.posts.count %></div>
@@ -20,11 +22,11 @@
     <div class="post-container mb-1">
     <% @user.recent_posts.each_with_index do |post, index| %>
       <div class="flex post-comment">
-        <%= link_to user_post_path(@user, post),  class: "bio flex-c" do %>
+        <%= link_to user_post_path(@user, post), id: "user-post-link-#{@user.id}",  class: "bio flex-c" do %>
           <p>post #<%= index + 1 %> </p>  </p>post-id:  <%= post.id %>
           <span><%= post.text %></span>
           <%= link_to new_comment_path(user_id: @user.id, post_id: post.id), class: "mr-1 absolute bottom-left-cornor mb-1 btn" do %><p>Comment on this post</p><% end %>
-        
+        <div class="find-me">find-me</div>
         <% end %>
         <div class="comment-likes flex gap-1">
           <div class="flex-c gap-3">
@@ -36,10 +38,10 @@
         </div>
       </div>
     <% end %>
-    <div class="  flex-centered">
-      <div class="flex">
-          <%= link_to user_posts_path(@user), class: "btn" do %><p>See all posts</p><% end %>
-      </div>
+    <div class="flex-centered">
+    <div class="flex">
+      <%= link_to user_posts_path(@user), class: "btn see-all-posts", title: "See all posts" do %><p>Comment on this posta</p><% end %>
+    </div>
     </div>
     </div> 
 </body>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -40,7 +40,7 @@
     <% end %>
     <div class="flex-centered">
     <div class="flex">
-      <%= link_to user_posts_path(@user), class: "btn see-all-posts", title: "See all posts" do %><p>Comment on this post</p><% end %>
+      <%= link_to user_posts_path(@user), class: "btn see-all-posts", title: "See all posts" do %><p>See all posts</p><% end %>
     </div>
     </div>
     </div> 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,6 +8,11 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Use the Capybara driver for feature/integration tests
+  config.use_transactional_fixtures = false
+  config.asset_host = 'http://localhost:3000' # Adjust the host as needed for your local setup
+  
+
   # Turn false under Spring and add config.action_view.cache_template_loading = true.
   config.cache_classes = true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "users#index"
 
-  # Homepage route
-  get 'users', to: 'home#index', as: :users
+  get 'users', to: 'users#index', as: :users
 
   # User profile route
   get 'users/:id', to: 'users#show', as: :user

--- a/test/integration/posts_view_test.rb
+++ b/test/integration/posts_view_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class PostsViewTest < ActionDispatch::IntegrationTest
+  fixtures :users, :posts, :comments
+
+  setup do
+    @user = users(:one)
+    @post = posts(:one)
+    @comment = comments(:one)
+  end
+
+  test "visiting a user's posts index page" do
+    visit user_posts_path(@user)
+
+    # Test if one can see the user's profile picture.
+    assert page.has_content?(@user.photo)
+
+    # Test if one can see the user's username.
+    assert page.has_content?(@user.name)
+
+    # Test if one can see the number of posts the user has written.
+    assert page.has_content?("Number of posts: #{users(:one).posts.count}")
+
+    # Test if one can see a post's title.
+    assert page.has_content?(@post.title)
+
+    # Test if one can see some of the post's body.
+    assert page.has_content?(@post.text)
+
+    # Test if one can see the first comments on a post.
+    assert page.has_content?(@comment.text)
+
+    # Test if one can see how many comments a post has.
+    assert page.has_content?("Comments: #{@post.comments.count}")
+
+    # Test if one can see how many likes a post has.
+    assert page.has_content?("Likes: #{@post.likes.count}")
+
+    # Test if one can see a section for pagination if there are more posts than fit on the view. (You can add this test if applicable.)
+    end
+    # Test when I click on a post, it redirects me to that post's show page. 
+   
+    # Test when I click on a post, it redirects me to that post's show page. (You can add this test if applicable.)
+end

--- a/test/integration/posts_view_test.rb
+++ b/test/integration/posts_view_test.rb
@@ -37,25 +37,25 @@ class PostsViewTest < ActionDispatch::IntegrationTest
 
     # Test if one can see how many likes a post has.
     assert page.has_content?("Likes: #{@post.likes.count}")
-    
-    # Test when I click on a post, it redirects me to that post's show page. 
-end
-    # Test if one can see a section for pagination if there are more posts than fit on the view.
-    test "viewing posts with pagination" do
-        visit user_posts_path(@user)
-        # Check if the first page of posts is displayed using fixture data
-        assert page.has_content?(posts(:one).title)
-        assert page.has_content?(posts(:two).title)
-    end
 
     # Test when I click on a post, it redirects me to that post's show page.
-    test "clicking on a post redirects to show page" do
-        post = @user.posts.first
+  end
+  # Test if one can see a section for pagination if there are more posts than fit on the view.
+  test 'viewing posts with pagination' do
+    visit user_posts_path(@user)
+    # Check if the first page of posts is displayed using fixture data
+    assert page.has_content?(posts(:one).title)
+    assert page.has_content?(posts(:two).title)
+  end
 
-        visit user_posts_path(@user)
-        # Click on the link of the first post
-        click_on "user-post-link-#{@user.id}"
-        # Check if it redirects to the show page of that post
-        assert_current_path(user_post_path(@user, post))
-    end
+  # Test when I click on a post, it redirects me to that post's show page.
+  test 'clicking on a post redirects to show page' do
+    post = @user.posts.first
+
+    visit user_posts_path(@user)
+    # Click on the link of the first post
+    click_on "user-post-link-#{@user.id}"
+    # Check if it redirects to the show page of that post
+    assert_current_path(user_post_path(@user, post))
+  end
 end

--- a/test/integration/posts_view_test.rb
+++ b/test/integration/posts_view_test.rb
@@ -1,0 +1,61 @@
+# test/integration/posts_view_test.rb
+
+require 'test_helper'
+
+class PostsViewTest < ActionDispatch::IntegrationTest
+  fixtures :users, :posts, :comments
+
+  setup do
+    @user = users(:one)
+    @post = posts(:one)
+    @comment = comments(:one)
+  end
+
+  test "visiting a user's posts index page" do
+    visit user_posts_path(@user)
+
+    # Test if one can see the user's profile picture.
+    assert page.has_content?(@user.photo)
+
+    # Test if one can see the user's username.
+    assert page.has_content?(@user.name)
+
+    # Test if one can see the number of posts the user has written.
+    assert page.has_content?("Number of posts: #{users(:one).posts.count}")
+
+    # Test if one can see a post's title.
+    assert page.has_content?(@post.title)
+
+    # Test if one can see some of the post's body.
+    assert page.has_content?(@post.text)
+
+    # Test if one can see the first comments on a post.
+    assert page.has_content?(@comment.text)
+
+    # Test if one can see how many comments a post has.
+    assert page.has_content?("Comments: #{@post.comments.count}")
+
+    # Test if one can see how many likes a post has.
+    assert page.has_content?("Likes: #{@post.likes.count}")
+    
+    # Test when I click on a post, it redirects me to that post's show page. 
+end
+    # Test if one can see a section for pagination if there are more posts than fit on the view.
+    test "viewing posts with pagination" do
+        visit user_posts_path(@user)
+        # Check if the first page of posts is displayed using fixture data
+        assert page.has_content?(posts(:one).title)
+        assert page.has_content?(posts(:two).title)
+    end
+
+    # Test when I click on a post, it redirects me to that post's show page.
+    test "clicking on a post redirects to show page" do
+        post = @user.posts.first
+
+        visit user_posts_path(@user)
+        # Click on the link of the first post
+        click_on "user-post-link-#{@user.id}"
+        # Check if it redirects to the show page of that post
+        assert_current_path(user_post_path(@user, post))
+    end
+end

--- a/test/integration/posts_view_test.rb
+++ b/test/integration/posts_view_test.rb
@@ -58,4 +58,31 @@ class PostsViewTest < ActionDispatch::IntegrationTest
     # Check if it redirects to the show page of that post
     assert_current_path(user_post_path(@user, post))
   end
+
+  test 'viewing a post shows post details and comments' do
+    visit user_post_path(@user, @post)
+
+    # Test if the post's title is visible
+    assert page.has_content?(@post.title)
+
+    # Test if the post's author is visible
+    assert page.has_content?(@post.author.name)
+
+    # Test if the number of comments the post has is visible
+    assert page.has_content?("comments #{@post.comments.count}")
+
+    # Test if the number of likes the post has is visible
+    assert page.has_content?("likes #{@post.likes.count}")
+
+    # Test if the post's body is visible
+    assert page.has_content?(@post.text)
+
+    # Test if the username of each commentor is visible
+    @post.comments.each do |comment|
+      assert page.has_content?(comment.author.name)
+      assert page.has_content?(comment.text)
+    end
+
+    # Test if the comment each commentor left is visible
+  end
 end

--- a/test/integration/users_view_test.rb
+++ b/test/integration/users_view_test.rb
@@ -46,14 +46,21 @@ class UsersViewTest < ActionDispatch::IntegrationTest
     end
 
     # Test if one can see a button that lets me view all of a user's posts.
-    # assert_selector 'a.btn.see-all-posts', text: 'See all posts', href: user_posts_path(@user)
+    assert page.has_link?('See all posts', href: user_posts_path(@user))
 
     # Test if one I click a user's post, it redirects me to that post's show page.
     click_on "user-post-link-#{@user.id}"
     assert_current_path(user_post_path(@user, users(:one).posts.first))
+  end
+
+  test "visiting a user's show page and clicking to see all posts" do
+    visit user_path(@user)
+
+    # Test if one can see a button that lets me view all of a user's posts.
+    assert page.has_link?('See all posts', href: user_posts_path(@user))
 
     # Test if one I click to see all posts, it redirects me to the user's post's index page.
-    # click_on 'See all posts'
-    # assert_current_path(user_posts_path(@user))
+    click_on 'See all posts'
+    assert_current_path(user_posts_path(@user))
   end
 end

--- a/test/integration/users_view_test.rb
+++ b/test/integration/users_view_test.rb
@@ -28,11 +28,8 @@ class UsersViewTest < ActionDispatch::IntegrationTest
   test "visiting a user's show page" do
     visit user_path(@user)
 
-    # Test if one can see the user's username.
-    assert page.has_content?(@user.name)
-
     # Test if one can see the user's profile picture.
-    # assert page.has_css?(".user-photo img[src='#{@user.photo}']")
+    assert page.has_content?(@user.photo)
 
     # Test if one can see the user's username.
     assert page.has_content?(@user.name)
@@ -48,12 +45,18 @@ class UsersViewTest < ActionDispatch::IntegrationTest
       assert page.has_content?(post.title)
     end
 
+    # Test if one can see a button that lets me view all of a user's posts.
+    # assert_selector 'a.btn.see-all-posts', text: 'See all posts', href: user_posts_path(@user)
+    
     # Test if one I click a user's post, it redirects me to that post's show page.
     click_on "user-post-link-#{@user.id}"
     assert_current_path(user_post_path(@user, users(:one).posts.first))
+
+    # Test if one I click to see all posts, it redirects me to the user's post's index page.
+    # click_on 'See all posts'
+    # assert_current_path(user_posts_path(@user))
     
     # Test if one I click "Comment on this post", it redirects me to the comment creation page.
-    click_on "Comment on this post"
-    assert_current_path(new_comment_path(user_id: @user.id, post_id: users(:one).posts.first.id))
+    # assert_current_path(new_comment_path(user_id: @user.id, post_id: users(:one).posts.first.id))
   end
 end

--- a/test/integration/users_view_test.rb
+++ b/test/integration/users_view_test.rb
@@ -55,8 +55,5 @@ class UsersViewTest < ActionDispatch::IntegrationTest
     # Test if one I click to see all posts, it redirects me to the user's post's index page.
     # click_on 'See all posts'
     # assert_current_path(user_posts_path(@user))
-
-    # Test if one I click "Comment on this post", it redirects me to the comment creation page.
-    # assert_current_path(new_comment_path(user_id: @user.id, post_id: users(:one).posts.first.id))
   end
 end

--- a/test/integration/users_view_test.rb
+++ b/test/integration/users_view_test.rb
@@ -1,0 +1,53 @@
+# test/integration/users_view_test.rb
+
+require 'test_helper'
+
+class UsersViewTest < ActionDispatch::IntegrationTest
+  fixtures :users, :posts
+  setup do
+    @user = users(:one)
+    puts "@userrrrrrrrrr: #{@user.name}"
+    puts "@userrrrrrrrrr: #{@user.posts.count}"
+  end
+
+  test "visiting the users index page" do
+    visit users_path
+
+    # Test if I can see the username of all other users
+    assert page.has_content?(@user.name)
+
+    # Check if the profile picture is displayed for each user
+    assert page.has_content?(@user.photo)
+    
+    # Test if the number of posts each user has written can be seen.
+    assert page.has_content?("Number of posts:#{@user.posts_counter}")
+
+    # Test clicking on a user's name redirects to their show page
+    click_on "user-link-#{@user.id}"
+    assert_current_path(user_path(@user))
+  end
+
+  test "visiting a user's show page" do
+    visit user_path(@user)
+
+    # Test if one can see the user's profile picture.
+
+    # Test if one can see the user's username.
+
+    # Test if one can see the number of posts the user has written.
+
+    # Test if one can see the user's bio.
+
+    # Test if one can see the user's first 3 posts.
+
+    # Test if one can see a button that lets me view all of a user's posts.
+
+    # Test if one I click a user's post, it redirects me to that post's show page.
+
+    # Test if one I click to see all posts, it redirects me to the user's post's index page.
+    
+
+    assert page.has_content?(@user.name)
+    assert page.has_content?("Number of posts: #{@user.posts_counter}")
+  end
+end

--- a/test/integration/users_view_test.rb
+++ b/test/integration/users_view_test.rb
@@ -6,8 +6,6 @@ class UsersViewTest < ActionDispatch::IntegrationTest
   fixtures :users, :posts
   setup do
     @user = users(:one)
-    puts "@userrrrrrrrrr: #{@user.name}"
-    puts "@userrrrrrrrrr: #{@user.posts.count}"
   end
 
   test "visiting the users index page" do
@@ -30,24 +28,32 @@ class UsersViewTest < ActionDispatch::IntegrationTest
   test "visiting a user's show page" do
     visit user_path(@user)
 
+    # Test if one can see the user's username.
+    assert page.has_content?(@user.name)
+
     # Test if one can see the user's profile picture.
+    # assert page.has_css?(".user-photo img[src='#{@user.photo}']")
 
     # Test if one can see the user's username.
+    assert page.has_content?(@user.name)
 
     # Test if one can see the number of posts the user has written.
+    assert page.has_content?("Number of posts: #{users(:one).posts.count}")
 
     # Test if one can see the user's bio.
+    assert page.has_content?(@user.bio)
 
     # Test if one can see the user's first 3 posts.
-
-    # Test if one can see a button that lets me view all of a user's posts.
+    @user.recent_posts.limit(3).each do |post|
+      assert page.has_content?(post.title)
+    end
 
     # Test if one I click a user's post, it redirects me to that post's show page.
-
-    # Test if one I click to see all posts, it redirects me to the user's post's index page.
+    click_on "user-post-link-#{@user.id}"
+    assert_current_path(user_post_path(@user, users(:one).posts.first))
     
-
-    assert page.has_content?(@user.name)
-    assert page.has_content?("Number of posts: #{@user.posts_counter}")
+    # Test if one I click "Comment on this post", it redirects me to the comment creation page.
+    click_on "Comment on this post"
+    assert_current_path(new_comment_path(user_id: @user.id, post_id: users(:one).posts.first.id))
   end
 end

--- a/test/integration/users_view_test.rb
+++ b/test/integration/users_view_test.rb
@@ -8,7 +8,7 @@ class UsersViewTest < ActionDispatch::IntegrationTest
     @user = users(:one)
   end
 
-  test "visiting the users index page" do
+  test 'visiting the users index page' do
     visit users_path
 
     # Test if I can see the username of all other users
@@ -16,7 +16,7 @@ class UsersViewTest < ActionDispatch::IntegrationTest
 
     # Check if the profile picture is displayed for each user
     assert page.has_content?(@user.photo)
-    
+
     # Test if the number of posts each user has written can be seen.
     assert page.has_content?("Number of posts:#{@user.posts_counter}")
 
@@ -47,7 +47,7 @@ class UsersViewTest < ActionDispatch::IntegrationTest
 
     # Test if one can see a button that lets me view all of a user's posts.
     # assert_selector 'a.btn.see-all-posts', text: 'See all posts', href: user_posts_path(@user)
-    
+
     # Test if one I click a user's post, it redirects me to that post's show page.
     click_on "user-post-link-#{@user.id}"
     assert_current_path(user_post_path(@user, users(:one).posts.first))
@@ -55,7 +55,7 @@ class UsersViewTest < ActionDispatch::IntegrationTest
     # Test if one I click to see all posts, it redirects me to the user's post's index page.
     # click_on 'See all posts'
     # assert_current_path(user_posts_path(@user))
-    
+
     # Test if one I click "Comment on this post", it redirects me to the comment creation page.
     # assert_current_path(new_comment_path(user_id: @user.id, post_id: users(:one).posts.first.id))
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,8 @@ ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
 
+require 'capybara/rails' # Add this line to include Capybara
+
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
   parallelize(workers: :number_of_processors, with: :threads)
@@ -10,4 +12,10 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+end
+
+# Include Capybara DSL in ActionDispatch::IntegrationTest
+class ActionDispatch::IntegrationTest
+  include Capybara::DSL
+  # Other test configurations...
 end


### PR DESCRIPTION
## Changes made in this PR: 
- Solve N+1 problem when fetching all posts and their comments
 - Performance before:
 
 ![image](https://github.com/kalbek/blog-app/blob/development/user-user-posts-before.png?raw=true)

 - Performance after:

![image](https://github.com/kalbek/blog-app/assets/44664009/cdba2bf1-7992-402a-9235-fd8abffab41f)

- Write integration test using Capybara.
  - User index page:
    - I can see the username of all other users.
    - I can see the profile picture for each user.
    - I can see the number of posts each user has written.
    - When I click on a user, I am redirected to that user's show page. 
  - user show page:
    - I can see the user's profile picture.
    - I can see the user's username.
    - I can see the number of posts the user has written.
    - I can see the user's bio.
    - I can see the user's first 3 posts.
    - I can see a button that lets me view all of a user's posts.
    - When I click a user's post, it redirects me to that post's show page.
    - When I click to see all posts, it redirects me to the user's post's index page.
 - User post index page
   - I can see the user's profile picture.
    - I can see the user's username.
    - I can see the number of posts the user has written.
    - I can see a post's title.
    - I can see some of the post's body.
    - I can see the first comments on a post.
    - I can see how many comments a post has.
    - I can see how many likes a post has.
    - I can see a section for pagination if there are more posts than fit on the view.
   - When I click on a post, it redirects me to that post's show page. 
    - Post show page:
    - I can see the post's title.
    - I can see who wrote the post.
    - I can see how many comments it has.
    - I can see how many likes it has.
    - I can see the post body.
    - I can see the username of each commenter.
    - I can see the comment each commentor left.  